### PR TITLE
Support for Wave Mini

### DIFF
--- a/custom_components/airthings_wave/airthings.py
+++ b/custom_components/airthings_wave/airthings.py
@@ -26,6 +26,7 @@ CHAR_UUID_RADON_LONG_TERM_AVG = UUID('b42e0a4c-ade7-11e4-89d3-123b93f75cba')
 CHAR_UUID_ILLUMINANCE_ACCELEROMETER = UUID('b42e1348-ade7-11e4-89d3-123b93f75cba')
 CHAR_UUID_WAVE_PLUS_DATA = UUID('b42e2a68-ade7-11e4-89d3-123b93f75cba')
 CHAR_UUID_WAVE_2_DATA = UUID('b42e4dcc-ade7-11e4-89d3-123b93f75cba')
+CHAR_UUID_WAVEMINI_DATA = UUID('b42e3b98-ade7-11e4-89d3-123b93f75cba')
 
 Characteristic = namedtuple('Characteristic', ['uuid', 'name', 'format'])
 
@@ -49,7 +50,7 @@ class AirthingsDeviceInfo:
 
 sensors_characteristics_uuid = [CHAR_UUID_DATETIME, CHAR_UUID_TEMPERATURE, CHAR_UUID_HUMIDITY, CHAR_UUID_RADON_1DAYAVG,
                                 CHAR_UUID_RADON_LONG_TERM_AVG, CHAR_UUID_ILLUMINANCE_ACCELEROMETER,
-                                CHAR_UUID_WAVE_PLUS_DATA,CHAR_UUID_WAVE_2_DATA]
+                                CHAR_UUID_WAVE_PLUS_DATA,CHAR_UUID_WAVE_2_DATA,CHAR_UUID_WAVEMINI_DATA]
 
 sensors_characteristics_uuid_str = [str(x) for x in sensors_characteristics_uuid]
 
@@ -100,6 +101,18 @@ class Wave2Decode(BaseDecode):
         return data
 
 
+class WaveMiniDecode(BaseDecode):
+    def decode_data(self, raw_data):
+        val = super().decode_data(raw_data)
+        val = val[self.name]
+        data = {}
+        data['date_time'] = str(datetime.isoformat(datetime.now()))
+        data['temperature'] = round( val[1]/100.0 - 273.15,2)
+        data['humidity'] = val[3]/100.0
+        data['voc'] = val[4]*1.0
+        return data
+
+
 class WaveDecodeDate(BaseDecode):
     def decode_data(self, raw_data):
         val = super().decode_data(raw_data)[self.name]
@@ -123,7 +136,8 @@ sensor_decoders = {str(CHAR_UUID_WAVE_PLUS_DATA):WavePlussDecode(name="Pluss", f
                    str(CHAR_UUID_RADON_LONG_TERM_AVG):BaseDecode(name="radon_longterm_avg", format_type='H', scale=1.0),
                    str(CHAR_UUID_ILLUMINANCE_ACCELEROMETER):WaveDecodeIluminAccel(name="illuminance_accelerometer", format_type='BB', scale=1.0),
                    str(CHAR_UUID_TEMPERATURE):BaseDecode(name="temperature", format_type='h', scale=1.0/100.0),
-                   str(CHAR_UUID_WAVE_2_DATA):Wave2Decode(name="Wave2", format_type='<4B8H', scale=1.0),}
+                   str(CHAR_UUID_WAVE_2_DATA):Wave2Decode(name="Wave2", format_type='<4B8H', scale=1.0),
+                   str(CHAR_UUID_WAVEMINI_DATA):WaveMiniDecode(name="WaveMini", format_type='<HHHHHHLL', scale=1.0),}
 
 
 class AirthingsWaveDetect:


### PR DESCRIPTION
Support for the Wave Mini. Not tested since I don't have a Wave Mini, but should not have any impact one the others since it is just a new UUID with matching decoder. (And my Wave 2 and Wave plus still works)
The temperature calculation is a bit strange compared to the others - appear to be in Kelvin! Copied it from the original airthing code. 