### PR TITLE
added escape clause to while loop to eliminate retries after successfull connection: Closes #50 in my case

### DIFF
--- a/custom_components/airthings_wave/airthings.py
+++ b/custom_components/airthings_wave/airthings.py
@@ -178,6 +178,7 @@ class AirthingsWaveDetect:
             tries += 1
             try:
                 self._dev = btle.Peripheral(mac.lower())
+                break
             except Exception as e:
                 print(e)
                 if tries == retries:


### PR DESCRIPTION
The while loop will continue to create the Peripheral object, even if successful on the first go. On a nuc, this causes exceptions and ultimately a failure to connect.